### PR TITLE
Fix incorrect full-width "%" character

### DIFF
--- a/translations/client_zh_CN.ts
+++ b/translations/client_zh_CN.ts
@@ -2637,7 +2637,7 @@ for additional privileges during the process.</source>
     <message>
         <location filename="../src/gui/updater/ocupdater.cpp" line="143"/>
         <source>Downloading version %1. Please wait …</source>
-        <translation>正在下载版本 ％1。 请稍候 …</translation>
+        <translation>正在下载版本 %1。 请稍候 …</translation>
     </message>
     <message>
         <location filename="../src/gui/updater/ocupdater.cpp" line="145"/>
@@ -2657,7 +2657,7 @@ for additional privileges during the process.</source>
     <message>
         <location filename="../src/gui/updater/ocupdater.cpp" line="153"/>
         <source>Downloading %1. Please wait …</source>
-        <translation>正在下载 ％1。请稍候…</translation>
+        <translation>正在下载 %1。请稍候…</translation>
     </message>
     <message>
         <location filename="../src/gui/updater/ocupdater.cpp" line="155"/>


### PR DESCRIPTION
The full-width "%" character has blocked renderring message template. It should be half-width "%".

Signed-off-by: Wang Jiaxiang <iwangjiaxiang@outlook.com>

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
